### PR TITLE
Add Branded Token deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Use the ei20 executable for that:
 
 It will write `eip20TokenAddress` to your config file.
 
+## Branded Token
+
+To deploy a new Branded Token:
+
+```bash
+# Help:
+./src/bin/bt -h
+
+# Deploy JLP token (conversion rate 35 & decimals 1 => conversion rate 3.5):
+./src/bin/bt.js deploy config.json JLP "Jean-Luc Picard Token" 18 35 1
+```
+
+It will write `originBrandedTokenAddress` and `originBrandedTokenOrganizationAddress` to your config file.
+
 ## Mosaic Deployment
 
 Prerequisite: `eip20TokenAddress` in your config file.

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   "scripts": {},
   "dependencies": {
     "@openstfoundation/mosaic.js": "^0.10.0-beta.4",
+    "@openstfoundation/brandedtoken.js": "git@github.com:sarvesh-ost/brandedtoken.js.git#facilitator_should_use_contract_interact",
     "bn.js": "4.11.8",
     "js-scrypt": "0.2.0",
-    "web3": "^1.0.0-beta.37",
-    "web3-eth-accounts": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37",
+    "web3-eth-accounts": "1.0.0-beta.37"
   },
   "devDependencies": {
     "assert": "^1.4.1",

--- a/src/bin/bt.js
+++ b/src/bin/bt.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander');
+
+const ChainConfig = require('../config/chain_config');
+const Deployer = require('../deployer.js');
+const logger = require('../logger');
+
+const { version } = require('../../package.json');
+
+program
+  .version(version)
+  .name('bt')
+  .description('An executable to deploy and interact with a branded token.')
+  .on(
+    '--help',
+    () => {
+      console.log('');
+      console.log('Available subcommands:');
+      console.log('  deploy    deploy the JLP branded token');
+    },
+  );
+
+program
+  .command('deploy <config> <symbol> <name> <decimals> <conversion-rate> <conversion-rate-decimals>')
+  .action(async (configPath, symbol, name, decimals, conversionRate, conversionRateDecimals) => {
+    const chainConfig = new ChainConfig(configPath);
+    const deployer = new Deployer(chainConfig);
+
+    const {
+      organization,
+      brandedToken,
+    } = await deployer.deployBrandedToken(
+      symbol,
+      name,
+      decimals,
+      conversionRate,
+      conversionRateDecimals,
+    );
+
+    logger.info(`Deployed Branded Token "${symbol}" - ${name} to ${brandedToken.address}`);
+    chainConfig.update({
+      originBrandedTokenOrganizationAddress: organization.address,
+      originBrandedTokenAddress: brandedToken.address,
+    });
+    chainConfig.write(configPath);
+  })
+  .on(
+    '--help',
+    () => {
+      console.log('');
+      console.log('Arguments:');
+      console.log('  config                      path to a config file');
+      console.log('  symbol                      the token symbol; e.g. JLP');
+      console.log('  name                        the token name; e.g. Jean-Luc Picard Token');
+      console.log('  decimals                    the token decimals');
+      console.log('  conversion-rate             the conversion rate between Branded Token and OST');
+      console.log('  conversion-rate-decimals    the decimals of the conversion rate');
+    },
+  );
+
+program.parse(process.argv);


### PR DESCRIPTION
⚠️ **Blocked by https://github.com/OpenSTFoundation/brandedtoken.js/pull/105**

Resolves #10

Usage:
```
Usage: deploy [options] <config> <symbol> <name> <decimals> <conversion-rate> <conversion-rate-decimals>

Options:
  -h, --help  output usage information

Arguments:
  config                      path to a config file
  symbol                      the token symbol; e.g. JLP
  name                        the token name; e.g. Jean-Luc Picard Token
  decimals                    the token decimals
  conversion-rate             the conversion rate between Branded Token and OST
  conversion-rate-decimals    the decimals of the conversion rate
```

Example:

```bash
# Start with an empty config
echo "{}" > config.json
# Deploy branded token
node src/bin/bt.js deploy config.json JLP "Jean-Luc Picard Token" 18 35 1
```
