### PR TITLE
Set OSTPrime address and note about web3 ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ If you need to set up your nodes, you can use the scripts in [chains](./chains) 
 
 Copy the `config.json.dist` example to `config.json`.
 
+⚠️ You may need to change the web3 provider ports.
+
 ⚠️ You have to put in your `{origin,auxiliary}masterKey`!
 You also may want to change other parameters.
 If you don't put in the `{origin/auxiliary}deployerAddress`, you need to run the `refill` command to generate and fund them (see below).

--- a/src/config/chain_config.js
+++ b/src/config/chain_config.js
@@ -60,7 +60,7 @@ class ChainConfig {
         EIP20CoGateway: this.auxiliaryCoGatewayAddress,
         Anchor: this.auxiliaryAnchorAddress,
         UtilityToken: this.auxiliaryUtilityTokenAddress,
-        OSTPrime: this.auxiliaryOSTPrimeAddress,
+        OSTPrime: this.auxiliaryOSTPrimeAddress || '0x05cd5fcd2aeca6aea1a554fae9fac76ce52dc5d6',
       },
     );
 


### PR DESCRIPTION
As requested by Ben:
- sets the OSTPrime address for 200 in chain_config.js
- notes in the readme that web3 provider ports may differ from those in the config