### PR TITLE
Split deployment into separate steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Accounts are stored as encrypted Web3 key-vaults.
 
 ```bash
 # Help:
-./src/bin/accounts.js -h
+./src/bin/account.js -h
 
 # Create a new origin account
-./src/bin/accounts.js origin
+./src/bin/account.js origin
 
 # Create a new auxiliary account
-./src/bin/accounts.js auxiliary
+./src/bin/account.js auxiliary
 ```
 
 ## EIP20 Token
@@ -63,14 +63,18 @@ It will write `eip20TokenAddress` to your config file.
 
 Prerequisite: `eip20TokenAddress` in your config file.
 
-If you want to deploy gateways, use the `deploy` executable:
+If you want to deploy contracts to the chains, use the `deploy` executable:
 
 ```bash
 # Help:
 ./src/bin/deploy.js -h
 
-# Deployment:
-./src/bin/deploy.js config.json
+# Deployment of utility token with gateways (requires anchor addresses in your config):
+./src/bin/deploy.js utilityToken config.json
+
+# If you don't have anchor addresses, yet, you must deploy anchors first.
+# Deployment of anchors:
+./src/bin/deploy.js anchors config.json
 ```
 
 It will write contract addresses to your config file.

--- a/src/bin/deploy.js
+++ b/src/bin/deploy.js
@@ -12,8 +12,9 @@ const { version } = require('../../package.json');
 program
   .version(version)
   .name('deploy')
-  .description('An executable to deploy a utility token.')
-  .arguments('<config>')
+  .description('An executable to deploy a utility token.');
+
+program.command('utilityToken <config>')
   .action(
     async (configPath) => {
       await connected.run(
@@ -24,8 +25,6 @@ program
           chainConfig.update({
             originOrganizationAddress: contractInstances.originOrganization.address,
             auxiliaryOrganizationAddress: contractInstances.auxiliaryOrganization.address,
-            originAnchorAddress: contractInstances.originAnchor.address,
-            auxiliaryAnchorAddress: contractInstances.auxiliaryAnchor.address,
             originGatewayAddress: contractInstances.originGateway.address,
             auxiliaryCoGatewayAddress: contractInstances.auxiliaryCoGateway.address,
             auxiliaryUtilityTokenAddress: contractInstances.auxiliaryUtilityToken.address,
@@ -34,13 +33,33 @@ program
         },
       );
     },
-  )
-  .on(
-    '--help',
-    () => {
-      console.log('');
-      console.log('Arguments:');
-      console.log('  config     path to a config file');
+  );
+
+program.command('anchors <config>')
+  .action(
+    async (configPath) => {
+      await connected.run(
+        configPath,
+        async (chainConfig, connection) => {
+          const deployer = new Deployer(chainConfig, connection);
+          const [originAnchor, auxiliaryAnchor] = await deployer.deployAnchors();
+
+          chainConfig.update({
+            originAnchorAddress: originAnchor.address,
+            auxiliaryAnchorAddress: auxiliaryAnchor.address,
+          });
+          chainConfig.write(configPath);
+        },
+      );
     },
-  )
+  );
+
+program.on(
+  '--help',
+  () => {
+    console.log('');
+    console.log('Arguments:');
+    console.log('  config  path to a config file');
+  },
+)
   .parse(process.argv);

--- a/src/deployer.js
+++ b/src/deployer.js
@@ -14,6 +14,7 @@ class Deployer {
       },
       token: chainConfig.eip20TokenAddress,
       baseToken: chainConfig.simpleTokenAddress,
+      anchor: chainConfig.originAnchorAddress,
       burner: chainConfig.originBurnerAddress,
       masterKey: connection.originAccount.address,
     };
@@ -25,9 +26,102 @@ class Deployer {
       txOptions: {
         gasPrice: chainConfig.auxiliaryGasPrice,
       },
+      anchor: chainConfig.auxiliaryAnchorAddress,
       burner: chainConfig.auxiliaryBurnerAddress,
       masterKey: connection.auxiliaryAccount.address,
     };
+  }
+
+  /**
+   * Deploys two anchors, one each on origin and auxiliary.
+   *
+   * @returns {Anchor[]} An array, where the first item is the origin anchor and the second item is
+   *                     the auxiliary anchor.
+   */
+  async deployAnchors() {
+    const [originOrganization, auxiliaryOrganization] = await this._deployOrganization();
+
+    return Setup.anchors(
+      this.origin.web3,
+      this.auxiliary.web3,
+      {
+        remoteChainId: this.auxiliary.chainId,
+        // Anchors use ring buffers to limit the number of state roots they store:
+        maxStateRoots: '10',
+        organization: originOrganization.address,
+        organizationOwner: this.origin.masterKey,
+        deployer: this.origin.deployer,
+      },
+      {
+        // The chain id of the chain that is tracked by this anchor:
+        remoteChainId: this.origin.chainId,
+        // Anchors use ring buffers to limit the number of state roots they store:
+        maxStateRoots: '10',
+        organization: auxiliaryOrganization.address,
+        organizationOwner: this.auxiliary.masterKey,
+        deployer: this.auxiliary.deployer,
+      },
+      this.origin.txOptions,
+      this.auxiliary.txOptions,
+    );
+  }
+
+  /**
+   * Deploys organizations on both chains, a utility token on auxiliary, and gateways on both
+   * chains. Also sets the co-gateway in the utility token.
+   *
+   * @returns {Object} originOrganization, auxiliaryOrganization, originGateway, auxiliaryCoGateway,
+   *                   and auxiliaryUtilityToken.
+   */
+  async deployUtilityToken() {
+    logger.info('Deploying organization ');
+    const [originOrganization, auxiliaryOrganization] = await this._deployOrganization();
+
+    logger.info(`origin organization address: ${originOrganization.address}`);
+    logger.info(`auxiliary organization address:  ${auxiliaryOrganization.address}`);
+
+    logger.info('Deploying utility token ');
+    const auxiliaryUtilityToken = await this._deployUtilityToken(auxiliaryOrganization);
+
+    logger.info(`auxiliary utilityToken address ${auxiliaryUtilityToken.address}`);
+
+    logger.info('Deploying gateways');
+    const [originGateway, auxiliaryCoGateway] = await this._deployGateways(
+      originOrganization,
+      auxiliaryOrganization,
+      auxiliaryUtilityToken,
+    );
+
+    logger.info(`origin gateway address ${originGateway.address}`);
+    logger.info(`auxiliary coGateway address ${auxiliaryCoGateway.address}`);
+
+    logger.info('Setting cogateway in utility token');
+    // Fix me https://github.com/OpenSTFoundation/mosaic.js/issues/129
+    await auxiliaryUtilityToken.setCoGateway(
+      auxiliaryCoGateway.address,
+      this.auxiliary.txOptions,
+    );
+
+    logger.info('Deployment successful!!!');
+
+    return {
+      originOrganization,
+      auxiliaryOrganization,
+      originGateway,
+      auxiliaryCoGateway,
+      auxiliaryUtilityToken,
+    };
+  }
+
+  async deployTokenRules(auxiliaryEIP20Token, auxiliaryOrganization) {
+    logger.info('Deploying TokenRules');
+    const tokenRulesSetup = new OpenST.Setup.TokenRules(this.auxiliary.web3);
+    const response = await tokenRulesSetup.deploy(
+      auxiliaryOrganization,
+      auxiliaryEIP20Token,
+      this.auxiliary.txOptions,
+    );
+    return response.receipt.contractAddress;
   }
 
   _deployOrganization() {
@@ -53,35 +147,7 @@ class Deployer {
     );
   }
 
-  _deployAnchors(originOrganizationAddress, auxiliaryOrganizationAddress) {
-    return Setup.anchors(
-      this.origin.web3,
-      this.auxiliary.web3,
-      {
-        remoteChainId: this.auxiliary.chainId,
-        // Anchors use ring buffers to limit the number of state roots they store:
-        maxStateRoots: '10',
-        organization: originOrganizationAddress,
-        organizationOwner: this.origin.masterKey,
-        deployer: this.origin.deployer,
-      },
-      {
-        // The chain id of the chain that is tracked by this anchor:
-        remoteChainId: this.origin.chainId,
-        // Anchors use ring buffers to limit the number of state roots they store:
-        maxStateRoots: '10',
-        organization: auxiliaryOrganizationAddress,
-        organizationOwner: this.auxiliary.masterKey,
-        deployer: this.auxiliary.deployer,
-      },
-      this.origin.txOptions,
-      this.auxiliary.txOptions,
-    );
-  }
-
   async _deployGateways(
-    originAnchor,
-    auxiliaryAnchor,
     originOrganization,
     auxiliaryOrganization,
     auxiliaryUtilityToken,
@@ -92,7 +158,7 @@ class Deployer {
       {
         token: this.origin.token,
         baseToken: this.origin.baseToken,
-        stateRootProvider: originAnchor.address,
+        stateRootProvider: this.origin.anchor,
         bounty: '0',
         organization: originOrganization.address,
         burner: this.origin.burner,
@@ -101,7 +167,7 @@ class Deployer {
       },
       {
         utilityToken: auxiliaryUtilityToken.address,
-        stateRootProvider: auxiliaryAnchor.address,
+        stateRootProvider: this.auxiliary.anchor,
         bounty: '0',
         organization: auxiliaryOrganization.address,
         burner: this.auxiliary.burner,
@@ -123,73 +189,6 @@ class Deployer {
       auxiliaryOrganization.address,
       this.auxiliary.txOptions,
     );
-  }
-
-  async deployUtilityToken() {
-    logger.info('Deploying organization ');
-
-    const [originOrganization, auxiliaryOrganization] = await this._deployOrganization();
-
-    logger.info(`origin organization address: ${originOrganization.address}`);
-    logger.info(`auxiliary organization address:  ${auxiliaryOrganization.address}`);
-
-    logger.info('Deploying anchor');
-    const [originAnchor, auxiliaryAnchor] = await this._deployAnchors(
-      originOrganization.address,
-      auxiliaryOrganization.address,
-    );
-
-    logger.info(`origin anchor address ${originAnchor.address}`);
-    logger.info(`auxiliary anchor address${auxiliaryAnchor.address}`);
-
-    logger.info('Deploying utility token ');
-
-    const auxiliaryUtilityToken = await this._deployUtilityToken(auxiliaryOrganization);
-
-    logger.info(`auxiliary utilityToken address ${auxiliaryUtilityToken.address}`);
-
-    logger.info('Deploying gateways');
-
-    const [originGateway, auxiliaryCoGateway] = await this._deployGateways(
-      originAnchor,
-      auxiliaryAnchor,
-      originOrganization,
-      auxiliaryOrganization,
-      auxiliaryUtilityToken,
-    );
-
-    logger.info(`origin gateway address ${originGateway.address}`);
-    logger.info(`auxiliary coGateway address ${auxiliaryCoGateway.address}`);
-
-    logger.info('Setting cogateway in utility token');
-    // Fix me https://github.com/OpenSTFoundation/mosaic.js/issues/129
-    await auxiliaryUtilityToken.setCoGateway(
-      auxiliaryCoGateway.address,
-      this.auxiliary.txOptions,
-    );
-
-    logger.info('Deployment successful!!!');
-
-    return {
-      originOrganization,
-      auxiliaryOrganization,
-      originAnchor,
-      auxiliaryAnchor,
-      originGateway,
-      auxiliaryCoGateway,
-      auxiliaryUtilityToken,
-    };
-  }
-
-  async deployTokenRules(auxiliaryEIP20Token, auxiliaryOrganization) {
-    logger.info('Deploying TokenRules');
-    const tokenRulesSetup = new OpenST.Setup.TokenRules(this.auxiliary.web3);
-    const response = await tokenRulesSetup.deploy(
-      auxiliaryOrganization,
-      auxiliaryEIP20Token,
-      this.auxiliary.txOptions,
-    );
-    return response.receipt.contractAddress;
   }
 }
 


### PR DESCRIPTION
One sub-command to deploy anchors.
And a separate sub-command to deploy a utility token with gateways. This
second command expects anchors to exist in the config file.