### PR TITLE
In RegisterRule, ruleABI should be injected from a file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,10 +294,10 @@ Prerequisite: `tokenRules` and `worker` in your config file.
 
 ```bash
 # Help:
-node ./src/bin/registerRule.js --help
+node ./src/bin/register_rule.js --help
 
 # Register rule to TokenRules:
-node ./src/bin/registerRule.js config.json ruleName ruleAddress ruleAbiFilePath
+node ./src/bin/register_rule.js config.json ruleName ruleAddress ruleAbiFilePath
 ```
   
 * Replace `config.json` with the path to the configuration file.

--- a/README.md
+++ b/README.md
@@ -297,13 +297,13 @@ Prerequisite: `tokenRules` and `worker` in your config file.
 node ./src/bin/registerRule.js --help
 
 # Register rule to TokenRules:
-node ./src/bin/registerRule.js config.json ruleName ruleAddress ruleAbi
+node ./src/bin/registerRule.js config.json ruleName ruleAddress ruleAbiFilePath
 ```
   
 * Replace `config.json` with the path to the configuration file.
 * Replace `ruleName` with name of the rule.
 * Replace `ruleAddress` with address of the rule. 
-* Replace `ruleAbi` with abi of the rule. 
+* Replace `ruleAbiFilePath` with file path containing jsonabi of the rule. 
 
 ## Create User
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ node ./src/bin/registerRule.js config.json ruleName ruleAddress ruleAbiFilePath
 * Replace `config.json` with the path to the configuration file.
 * Replace `ruleName` with name of the rule.
 * Replace `ruleAddress` with address of the rule. 
-* Replace `ruleAbiFilePath` with file path containing jsonabi of the rule. 
+* Replace `ruleAbiFilePath` with file path containing abi of the rule. 
 
 ## Create User
 

--- a/src/bin/registerRule.js
+++ b/src/bin/registerRule.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
+const fs = require('fs');
 const program = require('commander');
-const Web3 = require('web3');
 const OpenST = require('@openstfoundation/openst.js');
 
 const connected = require('../connected');
@@ -14,10 +14,10 @@ const { version } = require('../../package.json');
 program
   .version(version)
   .name('RegisterRule')
-  .arguments('<config> <ruleName> <ruleAddress> <ruleAbi>')
+  .arguments('<config> <ruleName> <ruleAddress> <ruleAbiFilePath>')
   .description('An executable to register rules in tokenrules.')
   .action(
-    async (config, ruleName, ruleAddress, ruleAbi) => {
+    async (config, ruleName, ruleAddress, ruleAbiFilePath) => {
       await connected.run(
         config,
         async (chainConfig, connection) => {
@@ -30,6 +30,10 @@ program
             web3,
             chainConfig.openst.tokenRules,
           );
+          let ruleAbi;
+          if (fs.existsSync(ruleAbiFilePath)) {
+            ruleAbi = fs.readFileSync(ruleAbiFilePath).toString();
+          }
           await tokenRules.registerRule(ruleName, ruleAddress, ruleAbi, registerRuleTxOptions);
           logger.info(`Rule ${ruleName} registered!`);
           logger.info('Validating registered rule...');
@@ -49,14 +53,14 @@ program
     () => {
       console.log('');
       console.log('Arguments:');
-      console.log('  config       path to a config file');
-      console.log('  ruleName     Rule name to be registered');
-      console.log('  ruleAddress  Rule address to be registered');
-      console.log('  ruleAbi      Abi of the rule');
+      console.log('  config           path to a config file');
+      console.log('  ruleName         rule name to be registered');
+      console.log('  ruleAddress      rule address to be registered');
+      console.log('  ruleAbiFilePath  file path containing json abi of the rule');
       console.log('');
       console.log('Examples:');
       console.log('  Register rule in TokenRules:');
-      console.log('  $ registerRule.js config.json ruleName 0xa4aa50fbd4767085705db09e020a781e58e2fbf2 ruleAbi');
+      console.log('  $ registerRule.js config.json ruleName 0xa4aa50fbd4767085705db09e020a781e58e2fbf2 ruleAbiFilePath');
     },
   )
   .parse(process.argv);

--- a/src/bin/registerRule.js
+++ b/src/bin/registerRule.js
@@ -56,7 +56,7 @@ program
       console.log('  config           path to a config file');
       console.log('  ruleName         rule name to be registered');
       console.log('  ruleAddress      rule address to be registered');
-      console.log('  ruleAbiFilePath  file path containing json abi of the rule');
+      console.log('  ruleAbiFilePath  file path containing abi of the rule');
       console.log('');
       console.log('Examples:');
       console.log('  Register rule in TokenRules:');

--- a/src/bin/registerRule.js
+++ b/src/bin/registerRule.js
@@ -60,7 +60,7 @@ program
       console.log('');
       console.log('Examples:');
       console.log('  Register rule in TokenRules:');
-      console.log('  $ registerRule.js config.json ruleName 0xa4aa50fbd4767085705db09e020a781e58e2fbf2 ruleAbiFilePath');
+      console.log('  $ registerRule.js config.json PricerRule 0xa4aa50fbd4767085705db09e020a781e58e2fbf2 /mnt/rules/PricerRule.abi');
     },
   )
   .parse(process.argv);

--- a/src/bin/register_rule.js
+++ b/src/bin/register_rule.js
@@ -60,7 +60,7 @@ program
       console.log('');
       console.log('Examples:');
       console.log('  Register rule in TokenRules:');
-      console.log('  $ registerRule.js config.json PricerRule 0xa4aa50fbd4767085705db09e020a781e58e2fbf2 /mnt/rules/PricerRule.abi');
+      console.log('  $ register_rule.js config.json PricerRule 0xa4aa50fbd4767085705db09e020a781e58e2fbf2 path_to_rule.abi');
     },
   )
   .parse(process.argv);


### PR DESCRIPTION
rule ABIs can be very long string. It doesn't work if it's injected from command line.
So JLP users can pass ruleAbiFilePath as an argument.

The JLP extracts the ABI string from the ruleAbiFilePath and registers to TokenRules contract.
Updated command:
```
node ./src/bin/registerRule.js config.json ruleName ruleAddress ruleAbiFilePath
``` 

Fixes #49 