### PR TITLE
Added funder in tests, it creates accounts and fund them using faucet

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "url": "https://github.com/benjaminbollen/JLP/issues"
   },
   "scripts": {
-    "test":"mocha --recursive --timeout 120000 test --exit"
+    "test": "node ./test/run.js"
   },
   "dependencies": {
+    "@openstfoundation/brandedtoken.js": "^0.10.0-alpha.2",
     "@openstfoundation/mosaic.js": "^0.10.0-beta.4",
-    "@openstfoundation/brandedtoken.js": "https://github.com/sarvesh-ost/brandedtoken.js.git#Branded_token_setup",
     "@openstfoundation/openst.js": "https://github.com/OpenST/openst.js.git#develop",
+    "axios": "^0.18.0",
     "bn.js": "4.11.8",
     "inquirer": "^6.2.2",
     "js-scrypt": "0.2.0",

--- a/src/bin/account.js
+++ b/src/bin/account.js
@@ -4,6 +4,7 @@
 
 const program = require('commander');
 const Web3 = require('web3');
+const inquirer = require('inquirer');
 
 const Account = require('../account');
 const logger = require('../logger');
@@ -21,7 +22,27 @@ program
         process.exit(1);
       }
 
-      await Account.create(chain, new Web3());
+      const { password } = await inquirer.prompt({
+        type: 'password',
+        name: 'password',
+        message: 'Select a password to encrypt the account:',
+      });
+      await inquirer.prompt({
+        type: 'password',
+        name: 'password',
+        message: 'Repeat the password:',
+        validate: input => new Promise(
+          (resolve, reject) => {
+            if (input === password) {
+              resolve(true);
+            } else {
+              reject(new Error('Passwords don\'t match, please try again. (^C to abort)'));
+            }
+          },
+        ),
+      });
+
+      await Account.create(chain, new Web3(), password);
     },
   )
   .on(

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -53,6 +53,33 @@ class Connection {
     );
   }
 
+  static async openAndUnlockAccounts(
+    chainConfig,
+    originAccountConf,
+    auxiliaryAccountConf,
+    password,
+  ) {
+    const originWeb3 = new Web3();
+    const auxiliaryWeb3 = new Web3();
+    const originAccount = await Account.unlock(originAccountConf.name, originWeb3, password);
+    const auxiliaryAccount = await Account.unlock(
+      auxiliaryAccountConf.name,
+      auxiliaryWeb3,
+      password,
+    );
+    const originProvider = Provider.create('origin', originAccount, chainConfig);
+    const auxiliaryProvider = Provider.create('auxiliary', auxiliaryAccount, chainConfig);
+    originWeb3.setProvider(originProvider);
+    auxiliaryWeb3.setProvider(auxiliaryProvider);
+
+    return new Connection(
+      originWeb3,
+      auxiliaryWeb3,
+      originAccount,
+      auxiliaryAccount,
+    );
+  }
+
   /**
    * Closes an open connection.
    */

--- a/test/config_init.json.dist
+++ b/test/config_init.json.dist
@@ -1,6 +1,6 @@
 {
-  "originWeb3Provider": "ws://localhost:8547",
-  "auxiliaryWeb3Provider": "ws://localhost:8548",
+  "originWeb3Provider": "ws://167.99.252.47:8646",
+  "auxiliaryWeb3Provider": "ws://167.99.252.47:8647",
   "originChainId": 3,
   "auxiliaryChainId": 200,
   "simpleTokenAddress": "0xca954C91BE676cBC4D5Ab5F624b37402E5f0d957",

--- a/test/constants.js
+++ b/test/constants.js
@@ -10,10 +10,14 @@ const CONFIG_FILE_NAME = 'config.json';
 const CONFIG_FILE_PATH = path.join(__dirname, CONFIG_FILE_NAME);
 const CONFIG_INIT_FILE_NAME = 'config_init.json';
 const CONFIG_INIT_FILE_PATH = path.join(__dirname, CONFIG_INIT_FILE_NAME);
+const MOSAIC_FAUCET_URL = 'http://157.230.99.224:60500';
+const ROPSTEN_FAUCET_URL = 'https://ropsten.faucet.b9lab.com/tap';
 
 module.exports = {
   CONFIG_FILE_NAME,
   CONFIG_FILE_PATH,
   CONFIG_INIT_FILE_NAME,
   CONFIG_INIT_FILE_PATH,
+  MOSAIC_FAUCET_URL,
+  ROPSTEN_FAUCET_URL,
 };

--- a/test/constants.js
+++ b/test/constants.js
@@ -12,7 +12,7 @@ const CONFIG_INIT_FILE_NAME = 'config_init.json';
 const CONFIG_INIT_FILE_PATH = path.join(__dirname, CONFIG_INIT_FILE_NAME);
 const MOSAIC_FAUCET_URL = 'http://157.230.99.224:60500';
 const ROPSTEN_FAUCET_URL = 'https://ropsten.faucet.b9lab.com/tap';
-
+const ROPSTEN_REFUND_ADDRESS = '0xb436ba50d378d4bbc8660d312a13df6af6e89dfb'
 module.exports = {
   CONFIG_FILE_NAME,
   CONFIG_FILE_PATH,
@@ -20,4 +20,5 @@ module.exports = {
   CONFIG_INIT_FILE_PATH,
   MOSAIC_FAUCET_URL,
   ROPSTEN_FAUCET_URL,
+  ROPSTEN_REFUND_ADDRESS,
 };

--- a/test/funder.js
+++ b/test/funder.js
@@ -1,29 +1,33 @@
 const axios = require('axios');
+const Web3 = require('web3');
+const Mosaic = require('@openstfoundation/mosaic.js');
+
 const Account = require('../src/account');
-const { MOSAIC_FAUCET_URL, ROPSTEN_FAUCET_URL } = require('./constants');
+const { MOSAIC_FAUCET_URL, ROPSTEN_FAUCET_URL, ROPSTEN_REFUND_ADDRESS } = require('./constants');
 const shared = require('./shared');
 
 const DEFAULT_PASSWORD = 'JLP_PASSWORD';
 const ORIGIN_CHAIN_ID = 3;
 const AUXILIARY_CHAIN_ID = 200;
 
-async function addOriginAccount(name, web3) {
+const { BN } = Web3.utils;
+const addOriginAccount = async (name, web3) => {
   const accountAddress = await Account.create(name, web3, DEFAULT_PASSWORD);
   shared.accounts.origin[name] = {
     name,
     chainId: ORIGIN_CHAIN_ID,
     address: accountAddress,
   };
-}
+};
 
-async function addAuxiliaryAccount(name, web3) {
+const addAuxiliaryAccount = async (name, web3) => {
   const accountAddress = await Account.create(name, web3, DEFAULT_PASSWORD);
   shared.accounts.auxiliary[name] = {
     name,
     chainId: AUXILIARY_CHAIN_ID,
     address: accountAddress,
   };
-}
+};
 
 /**
  * This funds an account from faucet.
@@ -31,46 +35,54 @@ async function addAuxiliaryAccount(name, web3) {
  * @param {string} chainId Chain Id of chain where beneficiary will get fund.
  * @return {Promise<string>} Transaction hash returned by faucet.
  */
-function fundAccountFromMosaicFaucet(address, chainId) {
-  return new Promise((resolve, reject) => axios.post(MOSAIC_FAUCET_URL, {
+const fundAccountFromMosaicFaucet = (address, chainId) => new Promise(
+  (resolve, reject) => axios.post(MOSAIC_FAUCET_URL, {
     beneficiary: `${address}@${chainId}`,
   })
     .then(response => resolve(response.data))
-    .catch(error => reject(error)));
-}
+    .catch(error => reject(error)),
+);
 
-function fundAccountFromRopstenFaucet(address) {
-  return new Promise((resolve, reject) => axios.post(ROPSTEN_FAUCET_URL, {
+const fundAccountFromRopstenFaucet = address => new Promise(
+  (resolve, reject) => axios.post(ROPSTEN_FAUCET_URL, {
     toWhom: address,
   })
     .then(response => resolve(response.data))
-    .catch(error => reject(error)));
-}
+    .catch(error => reject(error)),
+);
 
-
-async function waitForFunding(
+const waitForFunding = async (
   originMosaicFaucetFundRequests,
   auxiliaryMosaicFaucetFundRequests,
   ropstenFaucetFundRequest,
   originWeb3,
   auxiliaryWeb3,
-) {
-  return Promise.all([
-    originMosaicFaucetFundRequests,
-    auxiliaryMosaicFaucetFundRequests,
-    ropstenFaucetFundRequest,
-  ]).then((faucetResponse) => {
-    const originTransactionHashes = faucetResponse[0].map(response => response.txHash);
-    const auxiliaryTransactionHashes = faucetResponse[1].map(response => response.txHash);
-    const ropstenTransactionHashes = faucetResponse[2].map(response => response.txHash);
+) => Promise.all([
+  originMosaicFaucetFundRequests,
+  auxiliaryMosaicFaucetFundRequests,
+  ropstenFaucetFundRequest,
+]).then((faucetResponse) => {
+  const originTransactionHashes = faucetResponse[0].map(response => response.txHash);
+  const auxiliaryTransactionHashes = faucetResponse[1].map(response => response.txHash);
+  const ropstenTransactionHashes = faucetResponse[2].map(response => response.txHash);
 
-    return Promise.all([
-      originWeb3.eth.getTransactionReceiptMined(originTransactionHashes),
-      auxiliaryWeb3.eth.getTransactionReceiptMined(auxiliaryTransactionHashes),
-      originWeb3.eth.getTransactionReceiptMined(ropstenTransactionHashes),
-    ]);
-  });
-}
+  return Promise.all([
+    originWeb3.eth.getTransactionReceiptMined(originTransactionHashes),
+    auxiliaryWeb3.eth.getTransactionReceiptMined(auxiliaryTransactionHashes),
+    originWeb3.eth.getTransactionReceiptMined(ropstenTransactionHashes),
+  ]).then(receipts => ({
+    receipts: {
+      originFaucetReceipts: receipts[0],
+      auxiliaryFaucetReceipts: receipts[1],
+      ropstenFaucetReceipts: receipts[2],
+    },
+    txHashes: {
+      originFaucetTXHashes: originTransactionHashes,
+      auxiliaryFaucetTXHashes: auxiliaryTransactionHashes,
+      ropstenFaucetTXHashes: ropstenTransactionHashes,
+    },
+  }));
+});
 
 function getTransactionReceiptMined(txHash, interval) {
   const self = this;
@@ -100,6 +112,77 @@ function getTransactionReceiptMined(txHash, interval) {
   throw new Error(`Invalid Type: ${txHash}`);
 }
 
+const faucetTransactionDetails = async (
+  originFaucetTXHashes,
+  auxiliaryFaucetTXHashes,
+  ropstenFaucetTXHashes,
+  originWeb3,
+  auxiliaryWeb3,
+) => {
+  // Get faucet address from one transaction.
+  const originTransaction = originWeb3.eth.getTransaction(originFaucetTXHashes[0]);
+  const auxiliaryTransaction = auxiliaryWeb3.eth.getTransaction(auxiliaryFaucetTXHashes[0]);
+  const ropstenTransaction = originWeb3.eth.getTransaction(ropstenFaucetTXHashes[0]);
+
+  return Promise.all(
+    [
+      originTransaction,
+      auxiliaryTransaction,
+      ropstenTransaction,
+    ],
+  ).then(transactions => ({
+    originTransactions: {
+      type: 'ERC20',
+      faucetAddress: transactions[0].from,
+      tokenAddress: transactions[0].to,
+
+    },
+    auxiliaryTransactions: {
+      type: 'BaseToken',
+      faucetAddress: transactions[1].from,
+    },
+    ropstenTransactions: {
+      type: 'BaseToken',
+      faucetAddress: ROPSTEN_REFUND_ADDRESS,
+    },
+  }));
+};
+
+const refundBaseTokenToFaucet = async (web3, from, faucetAddress) => {
+  const balance = new BN(await web3.eth.getBalance(from));
+  const gasPrice = new BN(await web3.eth.getGasPrice());
+  const transactionFee = gasPrice.muln(21000);
+  const refundAmount = balance.sub(transactionFee);
+  if (refundAmount.gt(0)) {
+    await web3.eth.sendTransaction(
+      {
+        to: faucetAddress,
+        from,
+        value: refundAmount,
+        gas: 21000,
+
+      },
+    );
+  }
+};
+
+const refundERC20TokenToFaucet = async (web3, from, faucetTransaction) => {
+  const gasPrice = new BN(await web3.eth.getGasPrice());
+  const token = new Mosaic.ContractInteract.EIP20Token(
+    web3, faucetTransaction.tokenAddress,
+  );
+  const balance = await token.balanceOf(from);
+
+  await token.contract.methods.transfer(
+    faucetTransaction.faucetAddress,
+    balance,
+  ).send({
+    from,
+    gasPrice,
+    gas: '100000',
+  });
+};
+
 module.exports = {
   getTransactionReceiptMined,
   waitForFunding,
@@ -107,5 +190,8 @@ module.exports = {
   fundAccountFromRopstenFaucet,
   addAuxiliaryAccount,
   addOriginAccount,
+  faucetTransactionDetails,
+  refundBaseTokenToFaucet,
+  refundERC20TokenToFaucet,
   DEFAULT_PASSWORD,
 };

--- a/test/funder.js
+++ b/test/funder.js
@@ -1,0 +1,111 @@
+const axios = require('axios');
+const Account = require('../src/account');
+const { MOSAIC_FAUCET_URL, ROPSTEN_FAUCET_URL } = require('./constants');
+const shared = require('./shared');
+
+const DEFAULT_PASSWORD = 'JLP_PASSWORD';
+const ORIGIN_CHAIN_ID = 3;
+const AUXILIARY_CHAIN_ID = 200;
+
+async function addOriginAccount(name, web3) {
+  const accountAddress = await Account.create(name, web3, DEFAULT_PASSWORD);
+  shared.accounts.origin[name] = {
+    name,
+    chainId: ORIGIN_CHAIN_ID,
+    address: accountAddress,
+  };
+}
+
+async function addAuxiliaryAccount(name, web3) {
+  const accountAddress = await Account.create(name, web3, DEFAULT_PASSWORD);
+  shared.accounts.auxiliary[name] = {
+    name,
+    chainId: AUXILIARY_CHAIN_ID,
+    address: accountAddress,
+  };
+}
+
+/**
+ * This funds an account from faucet.
+ * @param {string} address Beneficiary address where funds will be added;
+ * @param {string} chainId Chain Id of chain where beneficiary will get fund.
+ * @return {Promise<string>} Transaction hash returned by faucet.
+ */
+function fundAccountFromMosaicFaucet(address, chainId) {
+  return new Promise((resolve, reject) => axios.post(MOSAIC_FAUCET_URL, {
+    beneficiary: `${address}@${chainId}`,
+  })
+    .then(response => resolve(response.data))
+    .catch(error => reject(error)));
+}
+
+function fundAccountFromRopstenFaucet(address) {
+  return new Promise((resolve, reject) => axios.post(ROPSTEN_FAUCET_URL, {
+    toWhom: address,
+  })
+    .then(response => resolve(response.data))
+    .catch(error => reject(error)));
+}
+
+
+async function waitForFunding(
+  originMosaicFaucetFundRequests,
+  auxiliaryMosaicFaucetFundRequests,
+  ropstenFaucetFundRequest,
+  originWeb3,
+  auxiliaryWeb3,
+) {
+  return Promise.all([
+    originMosaicFaucetFundRequests,
+    auxiliaryMosaicFaucetFundRequests,
+    ropstenFaucetFundRequest,
+  ]).then((faucetResponse) => {
+    const originTransactionHashes = faucetResponse[0].map(response => response.txHash);
+    const auxiliaryTransactionHashes = faucetResponse[1].map(response => response.txHash);
+    const ropstenTransactionHashes = faucetResponse[2].map(response => response.txHash);
+
+    return Promise.all([
+      originWeb3.eth.getTransactionReceiptMined(originTransactionHashes),
+      auxiliaryWeb3.eth.getTransactionReceiptMined(auxiliaryTransactionHashes),
+      originWeb3.eth.getTransactionReceiptMined(ropstenTransactionHashes),
+    ]);
+  });
+}
+
+function getTransactionReceiptMined(txHash, interval) {
+  const self = this;
+  const transactionReceiptAsync = (resolve, reject) => {
+    self.getTransactionReceipt(txHash, (error, receipt) => {
+      if (error) {
+        reject(error);
+      } else if (receipt == null) {
+        setTimeout(
+          () => transactionReceiptAsync(resolve, reject),
+          interval || 500,
+        );
+      } else {
+        resolve(receipt);
+      }
+    });
+  };
+
+  if (Array.isArray(txHash) && txHash.length > 0) {
+    return Promise.all(txHash.map(
+      oneTxHash => self.getTransactionReceiptMined(oneTxHash, interval),
+    ));
+  }
+  if (typeof txHash === 'string') {
+    return new Promise(transactionReceiptAsync);
+  }
+  throw new Error(`Invalid Type: ${txHash}`);
+}
+
+module.exports = {
+  getTransactionReceiptMined,
+  waitForFunding,
+  fundAccountFromMosaicFaucet,
+  fundAccountFromRopstenFaucet,
+  addAuxiliaryAccount,
+  addOriginAccount,
+  DEFAULT_PASSWORD,
+};

--- a/test/funder.js
+++ b/test/funder.js
@@ -45,7 +45,7 @@
 
 /**
  * @typedef {Object} BaseCoinRefundTransaction
- * @property {string}  type Type of fund.
+ * @property {string}  type Type of fund, either ERC20 or base coin.
  * @property {string} faucetAddress Address of faucet.
  */
 

--- a/test/funder.js
+++ b/test/funder.js
@@ -29,7 +29,6 @@
  *                                                 from ropsten faucet
  */
 
-
 /**
  * @typedef {Object} FundingDetails
  *
@@ -112,26 +111,24 @@ const addAuxiliaryAccount = async (name, web3) => {
  * @param {string} chainId Chain Id of chain where beneficiary will get fund.
  * @return {Promise<string>} Transaction hash returned by faucet.
  */
-const fundAccountFromMosaicFaucet = (address, chainId) => new Promise(
-  (resolve, reject) => axios.post(MOSAIC_FAUCET_URL, {
+const fundAccountFromMosaicFaucet = async (address, chainId) => {
+  const response = await axios.post(MOSAIC_FAUCET_URL, {
     beneficiary: `${address}@${chainId}`,
-  })
-    .then(response => resolve(response.data))
-    .catch(error => reject(error)),
-);
+  });
+  return response.data.txHash;
+};
 
 /**
  * This funds an account from ropsten faucet.
  * @param {string} address Beneficiary address where funds will be added;
  * @return {Promise<string>} Transaction hash returned by faucet.
  */
-const fundAccountFromRopstenFaucet = address => new Promise(
-  (resolve, reject) => axios.post(ROPSTEN_FAUCET_URL, {
+const fundAccountFromRopstenFaucet = async (address) => {
+  const response = await axios.post(ROPSTEN_FAUCET_URL, {
     toWhom: address,
-  })
-    .then(response => resolve(response.data))
-    .catch(error => reject(error)),
-);
+  });
+  return response.data.txHash;
+};
 
 /**
  * This methods takes various faucet fund request as a promise and waits
@@ -154,9 +151,9 @@ const waitForFunding = (
   auxiliaryMosaicFaucetFundRequests,
   ropstenFaucetFundRequest,
 ]).then((faucetResponse) => {
-  const originTransactionHashes = faucetResponse[0].map(response => response.txHash);
-  const auxiliaryTransactionHashes = faucetResponse[1].map(response => response.txHash);
-  const ropstenTransactionHashes = faucetResponse[2].map(response => response.txHash);
+  const originTransactionHashes = faucetResponse[0];
+  const auxiliaryTransactionHashes = faucetResponse[1];
+  const ropstenTransactionHashes = faucetResponse[2];
 
   return Promise.all([
     originWeb3.eth.getTransactionReceiptMined(originTransactionHashes),
@@ -265,8 +262,8 @@ const faucetTransactionDetails = async (
 };
 
 /**
- * This method returns all the base token balance to faucet address from the
- * `from` address.
+ * This method returns all the base token balance to faucet address from a
+ * given address.
  * @param {Web3} web3 Instance of web3.
  * @param {string} from Address from which fund will be transferred.
  * @param {string} faucetAddress Address of the faucet.
@@ -283,7 +280,7 @@ const refundBaseTokenToFaucet = async (web3, from, faucetAddress) => {
         from,
         value: refundAmount,
         gas: 21000,
-
+        gasPrice,
       },
     );
   }

--- a/test/funder.js
+++ b/test/funder.js
@@ -39,13 +39,13 @@
 
 /**
  * @typedef {Object} ERC20RefundTransaction
- * @property {string}  type Type of fund.
+ * @property {string}  type Type of fund, either ERC20 or base coin.
  * @property {string} faucetAddress Address of faucet.
  * @property {string} tokenAddress Address of ERC20 contract.
  */
 
 /**
- * @typedef {Object} BaseTokenRefundTransaction
+ * @typedef {Object} BaseCoinRefundTransaction
  * @property {string}  type Type of fund.
  * @property {string} faucetAddress Address of faucet.
  */
@@ -56,10 +56,10 @@
  * @property {ERC20RefundTransaction} originTransactions Return to faucet
  *                                                        transaction detail for
  *                                                        origin chain.
- * @property {BaseTokenRefundTransaction} auxiliaryTransactions Return to faucet
+ * @property {BaseCoinRefundTransaction} auxiliaryTransactions Return to faucet
  *                                                        transaction detail for
  *                                                        auxiliary chain.
- * @property {BaseTokenRefundTransaction} ropstenTransactions Return to faucet
+ * @property {BaseCoinRefundTransaction} ropstenTransactions Return to faucet
  *                                                        transaction detail for
  *                                                        the ropsten.
  */
@@ -135,7 +135,7 @@ const fundAccountFromRopstenFaucet = address => new Promise(
 
 /**
  * This methods takes various faucet fund request as a promise and waits
- * till all the promises are not resolved.
+ * until all the promises are not resolved.
  * @param {Array<Promise>} originMosaicFaucetFundRequests
  * @param {Array<Promise>} auxiliaryMosaicFaucetFundRequests
  * @param {Array<Promise>} ropstenFaucetFundRequest
@@ -143,7 +143,7 @@ const fundAccountFromRopstenFaucet = address => new Promise(
  * @param {Web3} auxiliaryWeb3
  * @return {Promise<FundingDetails>}
  */
-const waitForFunding = async (
+const waitForFunding = (
   originMosaicFaucetFundRequests,
   auxiliaryMosaicFaucetFundRequests,
   ropstenFaucetFundRequest,

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -47,7 +47,7 @@ before(async () => {
     connection.originWeb3.eth.getTransactionReceiptMined = funder.getTransactionReceiptMined;
     connection.auxiliaryWeb3.eth.getTransactionReceiptMined = funder.getTransactionReceiptMined;
 
-    const originFundRequests = Promise.all([
+    const originERC20FundRequests = Promise.all([
       funder.fundAccountFromMosaicFaucet(
         shared.accounts.origin.originDeployer.address,
         shared.accounts.origin.originDeployer.chainId,
@@ -61,23 +61,23 @@ before(async () => {
       ),
     ]);
 
-    const ropstenFaucetFundRequest = Promise.all([
+    const originBaseCoinFundRequest = Promise.all([
       funder.fundAccountFromRopstenFaucet(
         shared.accounts.origin.originDeployer.address,
       ),
     ]);
     const receipts = await funder.waitForFunding(
-      originFundRequests,
+      originERC20FundRequests,
       auxiliaryFundRequests,
-      ropstenFaucetFundRequest,
+      originBaseCoinFundRequest,
       connection.originWeb3,
       connection.auxiliaryWeb3,
     );
 
     shared.faucetTransactions = await funder.faucetTransactionDetails(
-      receipts.txHashes.originFaucetTXHashes,
+      receipts.txHashes.originERC20FaucetTXHashes,
       receipts.txHashes.auxiliaryFaucetTXHashes,
-      receipts.txHashes.ropstenFaucetTXHashes,
+      receipts.txHashes.originBaseCoinFaucetTXHashes,
       connection.originWeb3,
       connection.auxiliaryWeb3,
     );
@@ -92,16 +92,16 @@ after(async () => {
   await funder.refundERC20TokenToFaucet(
     shared.connection.originWeb3,
     shared.accounts.origin.originDeployer.address,
-    shared.faucetTransactions.originTransactions,
+    shared.faucetTransactions.originERC20Transactions,
   );
   await Promise.all(
     [
-      funder.refundBaseTokenToFaucet(
+      funder.refundBaseCoinToFaucet(
         shared.connection.originWeb3,
         shared.accounts.origin.originDeployer.address,
-        shared.faucetTransactions.ropstenTransactions.faucetAddress,
+        shared.faucetTransactions.originBaseCoinTransactions.faucetAddress,
       ),
-      funder.refundBaseTokenToFaucet(
+      funder.refundBaseCoinToFaucet(
         shared.connection.auxiliaryWeb3,
         shared.accounts.auxiliary.auxiliaryDeployer.address,
         shared.faucetTransactions.auxiliaryTransactions.faucetAddress,

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -35,10 +35,11 @@ before(async () => {
     await funder.addAuxiliaryAccount('auxiliaryMasterKey', web3);
     await funder.addAuxiliaryAccount('auxiliaryWorker', web3);
 
-    const connection = await Connection.openAndUnlockAccounts(
+    const connection = await Connection.open(
       chainConfig,
-      shared.accounts.origin.originDeployer,
-      shared.accounts.auxiliary.auxiliaryDeployer,
+      shared.accounts.origin.originDeployer.name,
+      shared.accounts.auxiliary.auxiliaryDeployer.name,
+      funder.DEFAULT_PASSWORD,
       funder.DEFAULT_PASSWORD,
     );
     shared.connection = connection;

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -73,13 +73,41 @@ before(async () => {
       connection.auxiliaryWeb3,
     );
 
-    console.log('Keys funded with faucet  ', receipts.length);
+    shared.faucetTransactions = await funder.faucetTransactionDetails(
+      receipts.txHashes.originFaucetTXHashes,
+      receipts.txHashes.auxiliaryFaucetTXHashes,
+      receipts.txHashes.ropstenFaucetTXHashes,
+      connection.originWeb3,
+      connection.auxiliaryWeb3,
+    );
   } catch (error) {
     console.log(error);
     console.error(`Failed in before each hook ${error}`);
   }
 });
 
+after(async () => {
+  console.log('Refunding to faucet');
+  await funder.refundERC20TokenToFaucet(
+    shared.connection.originWeb3,
+    shared.accounts.origin.originDeployer.address,
+    shared.faucetTransactions.originTransactions,
+  );
+  await Promise.all(
+    [
+      funder.refundBaseTokenToFaucet(
+        shared.connection.originWeb3,
+        shared.accounts.origin.originDeployer.address,
+        shared.faucetTransactions.ropstenTransactions.faucetAddress,
+      ),
+      funder.refundBaseTokenToFaucet(
+        shared.connection.auxiliaryWeb3,
+        shared.accounts.auxiliary.auxiliaryDeployer.address,
+        shared.faucetTransactions.auxiliaryTransactions.faucetAddress,
+      ),
+    ],
+  );
+});
 /**
  * Writes the current chain config object to disk, overwriting the previous chain configuration
  * file.e

--- a/test/sample.js
+++ b/test/sample.js
@@ -1,6 +1,0 @@
-'use strict';
-
-describe('Sample test suit ', () => {
-  it('always passing test', () => {
-  });
-});

--- a/test/shared.js
+++ b/test/shared.js
@@ -17,4 +17,5 @@ module.exports = {
     origin: {},
     auxiliary: {},
   },
+  faucetReceipts: {},
 };

--- a/test/shared.js
+++ b/test/shared.js
@@ -13,4 +13,8 @@
 module.exports = {
   chainConfig: undefined,
   connection: undefined,
+  accounts: {
+    origin: {},
+    auxiliary: {},
+  },
 };


### PR DESCRIPTION
This PR is about adding funder in the smoke tests. 
It implements a funder which creates different accounts before running tests and funds them with `ropsten` faucet and `mosaic` faucet. 

- [x] Create a new account, fund them with the faucet.  
- [x] Refund remaining amount to the faucet.

🚫 Blocked by #58 