### PR TITLE
Test: smoke tests DelayedRecoveryModule.resetRecoveryOwner

### DIFF
--- a/src/openst.js
+++ b/src/openst.js
@@ -21,8 +21,8 @@ class OpenST {
     const tokenRulesTxOptions = this.auxiliary.txOptions;
     const tokenRules = await TokenRules.deploy(
       this.auxiliary.web3,
-      auxiliaryOrganization,
-      auxiliaryEIP20Token,
+      auxiliaryOrganization.address,
+      auxiliaryEIP20Token.address,
       tokenRulesTxOptions,
     );
     return tokenRules.address;

--- a/src/openst.js
+++ b/src/openst.js
@@ -21,8 +21,8 @@ class OpenST {
     const tokenRulesTxOptions = this.auxiliary.txOptions;
     const tokenRules = await TokenRules.deploy(
       this.auxiliary.web3,
-      auxiliaryOrganization.address,
-      auxiliaryEIP20Token.address,
+      auxiliaryOrganization,
+      auxiliaryEIP20Token,
       tokenRulesTxOptions,
     );
     return tokenRules.address;

--- a/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
+++ b/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const { ContractInteract, Helpers } = require('@openstfoundation/openst.js');
+const { ContractInteract, Helpers } = require('@openst/openst.js');
 const shared = require('../../../shared');
 const Deployer = require('../../../../src/deployer');
 const OpenST = require('../../../../src/openst');

--- a/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
+++ b/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
@@ -32,7 +32,11 @@ describe('DelayedRecoveryModule', async () => {
     // Setup OpenST
     //  deploys master contracts
     const openst = new OpenST(chainConfig, connection);
-    await openst.setupOpenst(auxiliaryOrganization, auxiliaryUtilityToken) // setupOpenst updates chainConfig
+    //  setupOpenst updates chainConfig
+    await openst.setupOpenst(
+      auxiliaryOrganization.address,
+      auxiliaryUtilityToken.address,
+    )
 
     const userWallet = {
       owners: ["0x0000000000000000000000000000000000000002"], // cannot be 0x1

--- a/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
+++ b/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
@@ -1,0 +1,119 @@
+// 'use strict';
+
+const assert = require('assert');
+
+const { ContractInteract, Helpers } = require('@openstfoundation/openst.js');
+const shared = require('../../../shared');
+const Deployer = require('../../../../src/deployer');
+const OpenST = require('../../../../src/openst');
+
+describe('DelayedRecoveryModule', async () => {
+  it('resets recovery owner', async () => {
+    const chainConfig = shared.chainConfig;
+    const connection = shared.connection;
+    const web3 = connection.auxiliaryWeb3;
+
+    // Set auxiliaryOrganization address
+    const auxiliaryOrganization = {
+      address: connection.auxiliaryAccount.address,
+    };
+
+    // Add eip20TokenAddress to config for utility token deployment
+    chainConfig.update({
+      eip20TokenAddress: "0x0000000000000000000000000000000000000001",
+    });
+
+    // Deploy utility token
+    const deployer = new Deployer(chainConfig, connection);
+    const txOptions = deployer.auxiliary.txOptions;
+    txOptions.from = connection.auxiliaryAccount.address;
+    const auxiliaryUtilityToken = await deployer._deployUtilityToken(auxiliaryOrganization);
+
+    // Setup OpenST
+    //  deploys master contracts
+    const openst = new OpenST(chainConfig, connection);
+    await openst.setupOpenst(auxiliaryOrganization, auxiliaryUtilityToken) // setupOpenst updates chainConfig
+
+    const userWallet = {
+      owners: ["0x0000000000000000000000000000000000000002"], // cannot be 0x1
+      threshold: 1, // number of required confirmations
+      recoveryOwner: connection.auxiliaryAccount, // account that signs resetRecoveryOwner request
+      recoveryController: connection.auxiliaryAccount, // account that relays signed request
+      recoveryBlockDelay: 1, // not relevant to this test, must be greater than 0
+      sessionKeys: [], // not required
+      sessionKeySpendingLimits: [], // not required
+      sessionKeyExpirationHeights: [], // not required
+    }
+
+    // Setup user helper
+    //  adapted from ../../../../src/bin/create_user.js
+    const userHelper = new Helpers.User(
+      chainConfig.openst.tokenHolderMasterCopy,
+      chainConfig.openst.gnosisSafeMasterCopy,
+      chainConfig.openst.recoveryMasterCopy,
+      chainConfig.openst.createAndAddModules,
+      auxiliaryUtilityToken.address,
+      chainConfig.openst.tokenRules,
+      chainConfig.openst.userWalletFactory,
+      chainConfig.openst.proxyFactory,
+      web3,
+    );
+
+    // Create user wallet
+    //  deploys proxy contracts
+    //  adapted from ../../../../src/bin/create_user.js
+    const response = await userHelper.createUserWallet(
+      userWallet.owners,
+      userWallet.threshold,
+      userWallet.recoveryOwner.address,
+      userWallet.recoveryController.address,
+      userWallet.recoveryBlockDelay,
+      userWallet.sessionKeys,
+      userWallet.sessionKeySpendingLimits,
+      userWallet.sessionKeyExpirationHeights,
+      txOptions,
+    );
+
+    // Instantiate DelayedRecoveryModule
+    const { returnValues } = response.events.UserWalletCreated;
+    const gnosisSafeProxy = returnValues._gnosisSafeProxy;
+    const gnosisSafe = new ContractInteract.GnosisSafe(web3, gnosisSafeProxy);
+    const modules = await gnosisSafe.getModules();
+    const recoveryProxy = modules[0];
+    const delayedRecoveryModule = new ContractInteract.Recovery(web3, recoveryProxy);
+
+    // Confirm recoveryOwner is as expected
+    assert.strictEqual(
+      userWallet.recoveryOwner.address,
+      await delayedRecoveryModule.recoveryOwner(),
+    )
+
+    // Calculate recovery data
+    const newRecoveryOwner = "0x0000000000000000000000000000000000000003";
+    const resetRecoveryOwnerData = delayedRecoveryModule.resetRecoveryOwnerData(
+      userWallet.recoveryOwner.address,
+      newRecoveryOwner,
+    );
+
+    // Sign recovery data
+    //  openst.js extends Account to include signEIP712TypedData (via mosaic.js)
+    const signedRecoveryData = await userWallet
+      .recoveryOwner
+      .signEIP712TypedData(resetRecoveryOwnerData);
+
+    // Reset recoveryOwner
+    await delayedRecoveryModule.resetRecoveryOwner(
+      newRecoveryOwner,
+      signedRecoveryData.r,
+      signedRecoveryData.s,
+      signedRecoveryData.v,
+      txOptions,
+    );
+
+    // Confirm recoveryOwner is newRecoveryOwner
+    assert.strictEqual(
+      newRecoveryOwner,
+      await delayedRecoveryModule.recoveryOwner(),
+    )
+  });
+});

--- a/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
+++ b/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
@@ -33,7 +33,7 @@ describe('DelayedRecoveryModule', async () => {
     const userWallet = {
       owners: [mockAddresses.owner],
       threshold: 1, // number of required confirmations
-      recoveryOwner: connection.auxiliaryAccount, // account that signs resetRecoveryOwner request
+      recoveryOwner: await web3.eth.accounts.create(), // account that signs resetRecoveryOwner request
       recoveryController: connection.auxiliaryAccount, // account that relays signed request
       recoveryBlockDelay: 1, // not relevant to this test, must be greater than 0
       sessionKeys: [], // not required

--- a/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
+++ b/test/openst/gnosisSafeModules/delayedRecoveryModule/resetRecoveryOwner.js
@@ -97,12 +97,17 @@ describe('DelayedRecoveryModule', async () => {
       .signEIP712TypedData(resetRecoveryOwnerData);
 
     // Reset recoveryOwner
+    const resetRecoveryOwnerTxOptions = {
+      from: userWallet.recoveryController.address,
+      gasPrice: openst.auxiliary.txOptions.gasPrice,
+    }
+
     await delayedRecoveryModule.resetRecoveryOwner(
       mockAddresses.newRecoveryOwner,
       signedRecoveryData.r,
       signedRecoveryData.s,
       signedRecoveryData.v,
-      openst.auxiliary.txOptions,
+      resetRecoveryOwnerTxOptions,
     );
 
     // Confirm recoveryOwner is newRecoveryOwner


### PR DESCRIPTION
This PR affirms that resetting recovery owner does not 🚬. No 🚒 needed.

~✏️ N.B.: a change is made to `src/openst.js` to pass addresses and not accounts to the `TokenRule` helper.~
~✏️ N.B.: to minimize the surface area of potential errors, the test uses `Deployer._deployUtilityToken` rather than `Deployer.deployUtilityToken` to deploy a utility token.~

🤔 @pgev / @benjaminbollen: are there any concerns about resetting recovery owner to an inaccessible address? Cf., `initiateOwnershipTransfer` and `completeOwnershipTransfer` from `Owned`.

Resolves #56.